### PR TITLE
Add native streamer app shortcut integration

### DIFF
--- a/native/opennow-streamer/src/backend.rs
+++ b/native/opennow-streamer/src/backend.rs
@@ -492,7 +492,7 @@ fn preferred_hevc_profile_id(color_quality: ColorQuality) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol::{ColorQuality, SessionInfo, StreamSettings};
+    use crate::protocol::{ColorQuality, NativeStreamerShortcutBindings, SessionInfo, StreamSettings};
 
     fn context(resolution: &str) -> NativeStreamerSessionContext {
         NativeStreamerSessionContext {
@@ -516,6 +516,7 @@ mod tests {
                 enable_cloud_gsync: false,
                 native_transition_diagnostics: None,
             },
+            shortcuts: NativeStreamerShortcutBindings::default(),
         }
     }
 

--- a/native/opennow-streamer/src/gstreamer_backend.rs
+++ b/native/opennow-streamer/src/gstreamer_backend.rs
@@ -6,6 +6,7 @@ use crate::gstreamer_config::{
     resolve_d3d_fullscreen_sink, resolve_present_max_fps, NATIVE_D3D_FULLSCREEN_ENV,
     NATIVE_PRESENT_MAX_FPS_ENV, PRESENT_LIMITER_AUTO_SENTINEL,
 };
+use crate::gstreamer_platform::{clear_native_shortcut_bindings, set_native_shortcut_bindings};
 use crate::gstreamer_pipeline::{
     current_platform_label, init_gstreamer, native_video_backend_capabilities, GstreamerPipeline,
 };
@@ -124,6 +125,7 @@ impl NativeStreamerBackend for GstreamerBackend {
             }
         }
 
+        set_native_shortcut_bindings(&context.shortcuts);
         self.active_context = Some(context);
         self.pending_remote_ice.clear();
         self.remote_description_set = false;
@@ -192,6 +194,7 @@ impl NativeStreamerBackend for GstreamerBackend {
 
         let present_max_fps = resolve_present_max_fps(context.settings.fps);
         let d3d_fullscreen_sink = resolve_d3d_fullscreen_sink(context.settings.enable_cloud_gsync);
+        set_native_shortcut_bindings(&context.shortcuts);
         pipeline.set_present_max_fps(present_max_fps);
         pipeline.set_d3d_fullscreen_sink(d3d_fullscreen_sink);
         pipeline.configure_stats(&context, prepared.nvst_params.max_bitrate_kbps);
@@ -377,6 +380,7 @@ impl NativeStreamerBackend for GstreamerBackend {
         self.active_context = None;
         self.pending_remote_ice.clear();
         self.remote_description_set = false;
+        clear_native_shortcut_bindings();
         if let Some(pipeline) = self.pipeline.take() {
             if let Err(message) = pipeline.stop() {
                 return BackendReply {

--- a/native/opennow-streamer/src/gstreamer_input.rs
+++ b/native/opennow-streamer/src/gstreamer_input.rs
@@ -7,6 +7,8 @@ use crate::input::{
     GamepadInput, KeyboardPayload, MouseButtonPayload, MouseMovePayload, MouseWheelPayload,
     GAMEPAD_MAX_CONTROLLERS, PARTIALLY_RELIABLE_GAMEPAD_MASK_ALL,
 };
+#[cfg(target_os = "windows")]
+use crate::protocol::NativeStreamerShortcutAction;
 use crate::protocol::Event;
 use gst::glib;
 use gst::prelude::*;
@@ -98,6 +100,9 @@ impl GstreamerInputState {
 #[cfg(target_os = "windows")]
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum NativeWindowInputEvent {
+    Shortcut {
+        action: NativeStreamerShortcutAction,
+    },
     Key {
         pressed: bool,
         keycode: u16,
@@ -321,6 +326,7 @@ impl NativeWindowInputBridge {
                         send_native_window_input_events(
                             &input_thread_state,
                             &input_thread_channels,
+                            &thread_sender,
                             &pending_events,
                         );
                         if disconnected {
@@ -377,6 +383,7 @@ impl Drop for NativeWindowInputBridge {
 fn send_native_window_input_events(
     input_state: &GstreamerInputState,
     input_channels: &GstreamerInputChannels,
+    event_sender: &Option<Sender<Event>>,
     events: &[NativeWindowInputEvent],
 ) {
     if events.is_empty() || !input_state.ready.load(Ordering::SeqCst) {
@@ -404,7 +411,7 @@ fn send_native_window_input_events(
         }
 
         flush_pending_mouse_move(&encoder, input_channels, &mut pending_mouse_move);
-        send_encoded_native_window_input_event(&encoder, input_channels, event);
+        send_encoded_native_window_input_event(&encoder, input_channels, event_sender, event);
     }
     flush_pending_mouse_move(&encoder, input_channels, &mut pending_mouse_move);
 }
@@ -437,9 +444,16 @@ fn flush_pending_mouse_move(
 fn send_encoded_native_window_input_event(
     encoder: &InputEncoder,
     input_channels: &GstreamerInputChannels,
+    event_sender: &Option<Sender<Event>>,
     event: NativeWindowInputEvent,
 ) {
     let (payload, partially_reliable) = match event {
+        NativeWindowInputEvent::Shortcut { action } => {
+            if let Some(sender) = event_sender.as_ref() {
+                let _ = sender.send(Event::Shortcut { action });
+            }
+            return;
+        }
         NativeWindowInputEvent::Key {
             pressed,
             keycode,

--- a/native/opennow-streamer/src/gstreamer_platform.rs
+++ b/native/opennow-streamer/src/gstreamer_platform.rs
@@ -1,7 +1,7 @@
 #[cfg(target_os = "windows")]
 use crate::gstreamer_backend::send_log;
 #[cfg(target_os = "windows")]
-use crate::protocol::NativeRenderRect;
+use crate::protocol::{NativeRenderRect, NativeStreamerShortcutBindings};
 use crate::protocol::{Event, NativeRenderSurface};
 #[cfg(target_os = "windows")]
 use gst_video::prelude::*;
@@ -98,8 +98,32 @@ pub(crate) fn start_external_renderer_window_guard(
 }
 
 #[cfg(target_os = "windows")]
+pub(crate) fn set_native_shortcut_bindings(bindings: &NativeStreamerShortcutBindings) {
+    unsafe {
+        win32_renderer_window::set_shortcut_bindings(bindings.clone());
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn set_native_shortcut_bindings(_bindings: &NativeStreamerShortcutBindings) {
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn clear_native_shortcut_bindings() {
+    unsafe {
+        win32_renderer_window::clear_shortcut_bindings();
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn clear_native_shortcut_bindings() {
+}
+
+#[cfg(target_os = "windows")]
 pub(crate) mod win32_renderer_window {
     use crate::gstreamer_input::NativeWindowInputEvent;
+    use crate::protocol::{NativeStreamerShortcutAction, NativeStreamerShortcutBindings};
+    use crate::shortcuts::NativeShortcutMatcher;
     use std::collections::HashMap;
     use std::ffi::c_void;
     use std::ptr::{null, null_mut};
@@ -270,6 +294,7 @@ pub(crate) mod win32_renderer_window {
     struct PressedKey {
         keycode: u16,
         scancode: u16,
+        suppressed: bool,
     }
 
     #[derive(Clone, Copy)]
@@ -282,11 +307,13 @@ pub(crate) mod win32_renderer_window {
         OnceLock::new();
     static ORIGINAL_WNDPROCS: OnceLock<Mutex<HashMap<isize, isize>>> = OnceLock::new();
     static CAPTURED_HWND: OnceLock<Mutex<Option<isize>>> = OnceLock::new();
+    static PROTECTED_HWND: OnceLock<Mutex<Option<isize>>> = OnceLock::new();
     static PRESSED_KEYS: OnceLock<Mutex<HashMap<u16, PressedKey>>> = OnceLock::new();
     static STARTED_AT: OnceLock<Instant> = OnceLock::new();
     static ESCAPE_HOLD_HWND: OnceLock<Mutex<Option<isize>>> = OnceLock::new();
     static ESCAPE_HOLD_TOKEN: OnceLock<AtomicU64> = OnceLock::new();
     static ESCAPE_KEY_PRESS: OnceLock<Mutex<Option<EscapeKeyPress>>> = OnceLock::new();
+    static SHORTCUT_MATCHER: OnceLock<Mutex<NativeShortcutMatcher>> = OnceLock::new();
 
     #[link(name = "user32")]
     unsafe extern "system" {
@@ -348,6 +375,20 @@ pub(crate) mod win32_renderer_window {
         let slot = INPUT_EVENT_SENDER.get_or_init(|| Mutex::new(None));
         if let Ok(mut current) = slot.lock() {
             *current = sender;
+        }
+    }
+
+    pub unsafe fn set_shortcut_bindings(bindings: NativeStreamerShortcutBindings) {
+        let matcher = SHORTCUT_MATCHER.get_or_init(|| Mutex::new(NativeShortcutMatcher::default()));
+        if let Ok(mut current) = matcher.lock() {
+            *current = NativeShortcutMatcher::from_bindings(&bindings);
+        }
+    }
+
+    pub unsafe fn clear_shortcut_bindings() {
+        let matcher = SHORTCUT_MATCHER.get_or_init(|| Mutex::new(NativeShortcutMatcher::default()));
+        if let Ok(mut current) = matcher.lock() {
+            *current = NativeShortcutMatcher::default();
         }
     }
 
@@ -427,6 +468,11 @@ pub(crate) mod win32_renderer_window {
     }
 
     unsafe fn protect_renderer_window(hwnd: Hwnd) -> bool {
+        let protected_slot = PROTECTED_HWND.get_or_init(|| Mutex::new(None));
+        if let Ok(mut protected) = protected_slot.lock() {
+            *protected = Some(hwnd as isize);
+        }
+
         let mut configured = false;
         let current = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
         let desired = current & !(WS_EX_NOACTIVATE | WS_EX_TRANSPARENT);
@@ -633,6 +679,12 @@ pub(crate) mod win32_renderer_window {
 
     fn captured_hwnd() -> Option<isize> {
         CAPTURED_HWND
+            .get()
+            .and_then(|captured| captured.lock().ok().and_then(|captured| *captured))
+    }
+
+    fn protected_hwnd() -> Option<isize> {
+        PROTECTED_HWND
             .get()
             .and_then(|captured| captured.lock().ok().and_then(|captured| *captured))
     }
@@ -883,17 +935,34 @@ pub(crate) mod win32_renderer_window {
             handle_escape_keyboard_state(scancode, pressed);
             return;
         }
-        let was_present = keys.contains_key(&scancode);
+        let previous = keys.get(&scancode).copied();
         if pressed {
-            if was_present {
+            if previous.is_some() {
                 return;
             }
-            keys.insert(scancode, PressedKey { keycode, scancode });
+            let modifiers = current_modifier_flags(&keys);
+            if let Some(action) = shortcut_action_for_keypress(keycode, modifiers) {
+                keys.insert(scancode, PressedKey {
+                    keycode,
+                    scancode,
+                    suppressed: true,
+                });
+                drop(keys);
+                handle_shortcut_action(action);
+                return;
+            }
+            keys.insert(scancode, PressedKey {
+                keycode,
+                scancode,
+                suppressed: false,
+            });
         } else {
-            if !was_present {
+            let Some(previous) = keys.remove(&scancode) else {
+                return;
+            };
+            if previous.suppressed {
                 return;
             }
-            keys.remove(&scancode);
         }
         let modifiers = current_modifier_flags(&keys);
         drop(keys);
@@ -981,6 +1050,9 @@ pub(crate) mod win32_renderer_window {
 
         let timestamp_us = timestamp_us();
         for key in pressed {
+            if key.suppressed {
+                continue;
+            }
             emit_input_event(NativeWindowInputEvent::Key {
                 pressed: false,
                 keycode: key.keycode,
@@ -1067,6 +1139,32 @@ pub(crate) mod win32_renderer_window {
         keys.values()
             .any(|key| matches!(key.keycode, VK_LMENU | VK_RMENU | VK_MENU))
             || ((GetKeyState(VK_MENU as i32) as u16) & 0x8000) != 0
+    }
+
+    fn shortcut_action_for_keypress(
+        keycode: u16,
+        modifiers: u16,
+    ) -> Option<NativeStreamerShortcutAction> {
+        SHORTCUT_MATCHER
+            .get()
+            .and_then(|matcher| matcher.lock().ok())
+            .and_then(|matcher| matcher.match_keydown(keycode, modifiers))
+    }
+
+    unsafe fn handle_shortcut_action(action: NativeStreamerShortcutAction) {
+        match action {
+            NativeStreamerShortcutAction::TogglePointerLock => {
+                if let Some(hwnd) = captured_hwnd().or_else(protected_hwnd) {
+                    let hwnd = hwnd as Hwnd;
+                    if is_input_captured(hwnd) {
+                        release_input_capture(hwnd);
+                    } else {
+                        begin_input_capture(hwnd);
+                    }
+                }
+            }
+            _ => emit_input_event(NativeWindowInputEvent::Shortcut { action }),
+        }
     }
 
     fn legacy_mouse_button(message: Uint, wparam: Wparam) -> Option<(u8, bool)> {

--- a/native/opennow-streamer/src/main.rs
+++ b/native/opennow-streamer/src/main.rs
@@ -17,6 +17,7 @@ mod gstreamer_platform;
 mod gstreamer_transitions;
 mod input;
 mod protocol;
+mod shortcuts;
 mod sdp;
 
 use serde::Serialize;

--- a/native/opennow-streamer/src/protocol.rs
+++ b/native/opennow-streamer/src/protocol.rs
@@ -33,6 +33,8 @@ pub struct CommandEnvelope {
 pub struct NativeStreamerSessionContext {
     pub session: SessionInfo,
     pub settings: StreamSettings,
+    #[serde(default)]
+    pub shortcuts: NativeStreamerShortcutBindings,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -266,6 +268,40 @@ pub struct NativeRenderRect {
     pub height: i32,
 }
 
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeStreamerShortcutBindings {
+    #[serde(default)]
+    pub toggle_stats: String,
+    #[serde(default)]
+    pub toggle_pointer_lock: String,
+    #[serde(default)]
+    pub toggle_fullscreen: String,
+    #[serde(default)]
+    pub stop_stream: String,
+    #[serde(default)]
+    pub toggle_anti_afk: String,
+    #[serde(default)]
+    pub toggle_microphone: String,
+    #[serde(default)]
+    pub screenshot: String,
+    #[serde(default)]
+    pub toggle_recording: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum NativeStreamerShortcutAction {
+    ToggleStats,
+    TogglePointerLock,
+    ToggleFullscreen,
+    StopStream,
+    ToggleAntiAfk,
+    ToggleMicrophone,
+    Screenshot,
+    ToggleRecording,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct NativeStreamerCapabilities {
     #[serde(rename = "protocolVersion")]
@@ -483,6 +519,10 @@ pub enum Event {
     InputReady {
         #[serde(rename = "protocolVersion")]
         protocol_version: u16,
+    },
+    #[serde(rename = "shortcut")]
+    Shortcut {
+        action: NativeStreamerShortcutAction,
     },
     #[serde(rename = "video-stall")]
     VideoStall(VideoStallEvent),

--- a/native/opennow-streamer/src/shortcuts.rs
+++ b/native/opennow-streamer/src/shortcuts.rs
@@ -1,0 +1,305 @@
+use crate::protocol::{NativeStreamerShortcutAction, NativeStreamerShortcutBindings};
+
+const MODIFIER_SHIFT: u16 = 0x01;
+const MODIFIER_CTRL: u16 = 0x02;
+const MODIFIER_ALT: u16 = 0x04;
+const MODIFIER_META: u16 = 0x08;
+const SHORTCUT_MODIFIER_MASK: u16 = MODIFIER_SHIFT | MODIFIER_CTRL | MODIFIER_ALT | MODIFIER_META;
+
+const VK_BACK: u16 = 0x08;
+const VK_TAB: u16 = 0x09;
+const VK_RETURN: u16 = 0x0D;
+const VK_PAUSE: u16 = 0x13;
+const VK_CAPITAL: u16 = 0x14;
+const VK_ESCAPE: u16 = 0x1B;
+const VK_SPACE: u16 = 0x20;
+const VK_PRIOR: u16 = 0x21;
+const VK_NEXT: u16 = 0x22;
+const VK_END: u16 = 0x23;
+const VK_HOME: u16 = 0x24;
+const VK_LEFT: u16 = 0x25;
+const VK_UP: u16 = 0x26;
+const VK_RIGHT: u16 = 0x27;
+const VK_DOWN: u16 = 0x28;
+const VK_INSERT: u16 = 0x2D;
+const VK_DELETE: u16 = 0x2E;
+const VK_PRINT: u16 = 0x2C;
+const VK_LWIN: u16 = 0x5B;
+const VK_RWIN: u16 = 0x5C;
+const VK_APPS: u16 = 0x5D;
+const VK_NUMPAD0: u16 = 0x60;
+const VK_MULTIPLY: u16 = 0x6A;
+const VK_ADD: u16 = 0x6B;
+const VK_SEPARATOR: u16 = 0x6C;
+const VK_SUBTRACT: u16 = 0x6D;
+const VK_DECIMAL: u16 = 0x6E;
+const VK_DIVIDE: u16 = 0x6F;
+const VK_F1: u16 = 0x70;
+const VK_NUMLOCK: u16 = 0x90;
+const VK_SCROLL: u16 = 0x91;
+const VK_OEM_1: u16 = 0xBA;
+const VK_OEM_PLUS: u16 = 0xBB;
+const VK_OEM_COMMA: u16 = 0xBC;
+const VK_OEM_MINUS: u16 = 0xBD;
+const VK_OEM_PERIOD: u16 = 0xBE;
+const VK_OEM_2: u16 = 0xBF;
+const VK_OEM_3: u16 = 0xC0;
+const VK_OEM_4: u16 = 0xDB;
+const VK_OEM_5: u16 = 0xDC;
+const VK_OEM_6: u16 = 0xDD;
+const VK_OEM_7: u16 = 0xDE;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ShortcutBinding {
+    action: NativeStreamerShortcutAction,
+    keycode: u16,
+    modifiers: u16,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct NativeShortcutMatcher {
+    bindings: Vec<ShortcutBinding>,
+}
+
+impl NativeShortcutMatcher {
+    pub(crate) fn from_bindings(bindings: &NativeStreamerShortcutBindings) -> Self {
+        let mut parsed = Vec::new();
+        append_binding(
+            &mut parsed,
+            NativeStreamerShortcutAction::ToggleStats,
+            &bindings.toggle_stats,
+        );
+        append_binding(
+            &mut parsed,
+            NativeStreamerShortcutAction::TogglePointerLock,
+            &bindings.toggle_pointer_lock,
+        );
+        append_binding(
+            &mut parsed,
+            NativeStreamerShortcutAction::ToggleFullscreen,
+            &bindings.toggle_fullscreen,
+        );
+        append_binding(
+            &mut parsed,
+            NativeStreamerShortcutAction::StopStream,
+            &bindings.stop_stream,
+        );
+        append_binding(
+            &mut parsed,
+            NativeStreamerShortcutAction::ToggleAntiAfk,
+            &bindings.toggle_anti_afk,
+        );
+        append_binding(
+            &mut parsed,
+            NativeStreamerShortcutAction::ToggleMicrophone,
+            &bindings.toggle_microphone,
+        );
+        append_binding(
+            &mut parsed,
+            NativeStreamerShortcutAction::Screenshot,
+            &bindings.screenshot,
+        );
+        append_binding(
+            &mut parsed,
+            NativeStreamerShortcutAction::ToggleRecording,
+            &bindings.toggle_recording,
+        );
+        Self { bindings: parsed }
+    }
+
+    pub(crate) fn match_keydown(
+        &self,
+        keycode: u16,
+        modifiers: u16,
+    ) -> Option<NativeStreamerShortcutAction> {
+        let modifiers = modifiers & SHORTCUT_MODIFIER_MASK;
+        self.bindings
+            .iter()
+            .find(|binding| binding.keycode == keycode && binding.modifiers == modifiers)
+            .map(|binding| binding.action)
+    }
+}
+
+fn append_binding(
+    bindings: &mut Vec<ShortcutBinding>,
+    action: NativeStreamerShortcutAction,
+    raw: &str,
+) {
+    if let Some(binding) = parse_binding(action, raw) {
+        bindings.push(binding);
+    }
+}
+
+fn parse_binding(action: NativeStreamerShortcutAction, raw: &str) -> Option<ShortcutBinding> {
+    let mut modifiers = 0u16;
+    let mut keycode = None;
+
+    for token in raw.split('+').map(str::trim).filter(|token| !token.is_empty()) {
+        match token.to_ascii_uppercase().as_str() {
+            "CTRL" | "CONTROL" => modifiers |= MODIFIER_CTRL,
+            "ALT" | "OPTION" => modifiers |= MODIFIER_ALT,
+            "SHIFT" => modifiers |= MODIFIER_SHIFT,
+            "META" | "CMD" | "COMMAND" => modifiers |= MODIFIER_META,
+            _ => {
+                if keycode.is_some() {
+                    return None;
+                }
+                keycode = parse_key_token(token);
+            }
+        }
+    }
+
+    Some(ShortcutBinding {
+        action,
+        keycode: keycode?,
+        modifiers,
+    })
+}
+
+fn parse_key_token(token: &str) -> Option<u16> {
+    let upper = token.trim().to_ascii_uppercase();
+    if upper.len() == 1 {
+        let byte = upper.as_bytes()[0];
+        return match byte {
+            b'A'..=b'Z' | b'0'..=b'9' => Some(u16::from(byte)),
+            b',' => Some(VK_OEM_COMMA),
+            b'.' => Some(VK_OEM_PERIOD),
+            b'/' => Some(VK_OEM_2),
+            b';' => Some(VK_OEM_1),
+            b'\'' => Some(VK_OEM_7),
+            b'[' => Some(VK_OEM_4),
+            b']' => Some(VK_OEM_6),
+            b'\\' => Some(VK_OEM_5),
+            b'-' => Some(VK_OEM_MINUS),
+            b'=' => Some(VK_OEM_PLUS),
+            b'`' => Some(VK_OEM_3),
+            _ => None,
+        };
+    }
+
+    if let Some(function_index) = upper
+        .strip_prefix('F')
+        .and_then(|value| value.parse::<u16>().ok())
+    {
+        if (1..=24).contains(&function_index) {
+            return Some(VK_F1 + function_index - 1);
+        }
+    }
+
+    if let Some(numpad_index) = upper
+        .strip_prefix("NUMPAD")
+        .and_then(|value| value.parse::<u16>().ok())
+    {
+        if numpad_index <= 9 {
+            return Some(VK_NUMPAD0 + numpad_index);
+        }
+    }
+
+    match upper.as_str() {
+        "BACKSPACE" => Some(VK_BACK),
+        "TAB" => Some(VK_TAB),
+        "ENTER" | "NUMPADENTER" => Some(VK_RETURN),
+        "PAUSE" => Some(VK_PAUSE),
+        "CAPSLOCK" => Some(VK_CAPITAL),
+        "ESCAPE" => Some(VK_ESCAPE),
+        "SPACE" => Some(VK_SPACE),
+        "PAGEUP" => Some(VK_PRIOR),
+        "PAGEDOWN" => Some(VK_NEXT),
+        "END" => Some(VK_END),
+        "HOME" => Some(VK_HOME),
+        "ARROWLEFT" => Some(VK_LEFT),
+        "ARROWUP" => Some(VK_UP),
+        "ARROWRIGHT" => Some(VK_RIGHT),
+        "ARROWDOWN" => Some(VK_DOWN),
+        "INSERT" => Some(VK_INSERT),
+        "DELETE" => Some(VK_DELETE),
+        "PRINTSCREEN" => Some(VK_PRINT),
+        "APPS" | "MENU" => Some(VK_APPS),
+        "METALEFT" => Some(VK_LWIN),
+        "METARIGHT" => Some(VK_RWIN),
+        "NUMPADMULTIPLY" => Some(VK_MULTIPLY),
+        "NUMPADADD" => Some(VK_ADD),
+        "NUMPADSEPARATOR" => Some(VK_SEPARATOR),
+        "NUMPADSUBTRACT" => Some(VK_SUBTRACT),
+        "NUMPADDECIMAL" => Some(VK_DECIMAL),
+        "NUMPADDIVIDE" => Some(VK_DIVIDE),
+        "NUMLOCK" => Some(VK_NUMLOCK),
+        "SCROLLLOCK" => Some(VK_SCROLL),
+        "SEMICOLON" => Some(VK_OEM_1),
+        "EQUAL" => Some(VK_OEM_PLUS),
+        "COMMA" => Some(VK_OEM_COMMA),
+        "MINUS" => Some(VK_OEM_MINUS),
+        "PERIOD" => Some(VK_OEM_PERIOD),
+        "SLASH" => Some(VK_OEM_2),
+        "BACKQUOTE" => Some(VK_OEM_3),
+        "BRACKETLEFT" => Some(VK_OEM_4),
+        "BACKSLASH" => Some(VK_OEM_5),
+        "BRACKETRIGHT" => Some(VK_OEM_6),
+        "QUOTE" => Some(VK_OEM_7),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bindings() -> NativeStreamerShortcutBindings {
+        NativeStreamerShortcutBindings {
+            toggle_stats: "F3".to_owned(),
+            toggle_pointer_lock: "F8".to_owned(),
+            toggle_fullscreen: "F10".to_owned(),
+            stop_stream: "Ctrl+Shift+Q".to_owned(),
+            toggle_anti_afk: "Ctrl+Shift+K".to_owned(),
+            toggle_microphone: "Ctrl+Shift+M".to_owned(),
+            screenshot: "F11".to_owned(),
+            toggle_recording: "F12".to_owned(),
+        }
+    }
+
+    #[test]
+    fn matches_function_key_shortcuts_without_modifiers() {
+        let matcher = NativeShortcutMatcher::from_bindings(&bindings());
+
+        assert_eq!(
+            matcher.match_keydown(VK_F1 + 2, 0),
+            Some(NativeStreamerShortcutAction::ToggleStats)
+        );
+        assert_eq!(
+            matcher.match_keydown(VK_F1 + 10, 0),
+            Some(NativeStreamerShortcutAction::Screenshot)
+        );
+    }
+
+    #[test]
+    fn matches_exact_modifier_combinations() {
+        let matcher = NativeShortcutMatcher::from_bindings(&bindings());
+
+        assert_eq!(
+            matcher.match_keydown(u16::from(b'Q'), MODIFIER_CTRL | MODIFIER_SHIFT),
+            Some(NativeStreamerShortcutAction::StopStream)
+        );
+        assert_eq!(matcher.match_keydown(u16::from(b'Q'), MODIFIER_CTRL), None);
+        assert_eq!(
+            matcher.match_keydown(
+                u16::from(b'Q'),
+                MODIFIER_CTRL | MODIFIER_SHIFT | MODIFIER_ALT
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn ignores_invalid_bindings() {
+        let matcher = NativeShortcutMatcher::from_bindings(&NativeStreamerShortcutBindings {
+            toggle_stats: "Ctrl+Shift".to_owned(),
+            ..bindings()
+        });
+
+        assert_eq!(matcher.match_keydown(VK_F1 + 2, 0), None);
+        assert_eq!(
+            matcher.match_keydown(VK_F1 + 7, 0),
+            Some(NativeStreamerShortcutAction::TogglePointerLock)
+        );
+    }
+}

--- a/opennow-stable/src/main/nativeStreamer/manager.ts
+++ b/opennow-stable/src/main/nativeStreamer/manager.ts
@@ -1172,6 +1172,11 @@ export class NativeStreamerManager {
       return;
     }
 
+    if (message.type === "shortcut") {
+      this.options.emit({ type: "native-shortcut", action: message.action });
+      return;
+    }
+
     if (message.type === "video-stall") {
       const formatAge = (value: number | undefined): string => value === undefined ? "n/a" : `${value}ms`;
       const stats = [

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -12,6 +12,7 @@ import type {
   GameInfo,
   LoginProvider,
   MainToRendererSignalingEvent,
+  NativeStreamerShortcutAction,
   SessionInfo,
   SessionStopRequest,
   SavedAccount,
@@ -30,6 +31,7 @@ import {
 } from "@shared/gfn";
 import { GfnWebRtcClient } from "./gfn/webrtcClient";
 import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut } from "./shortcuts";
+import { dispatchStreamShortcutAction } from "./streamShortcutActions";
 import { useControllerNavigation } from "./controllerNavigation";
 import { useElapsedSeconds } from "./utils/useElapsedSeconds";
 import { useQueueAdRuntime } from "./hooks/useQueueAdRuntime";
@@ -700,16 +702,6 @@ export function App(): JSX.Element {
     settings.streamClientMode,
   ]);
 
-  const buildSignalingConnectRequest = useCallback((activeSession: SessionInfo): SignalingConnectRequest => {
-    const streamSettings = buildCurrentStreamSettings();
-    return {
-      sessionId: activeSession.sessionId,
-      signalingServer: activeSession.signalingServer,
-      signalingUrl: activeSession.signalingUrl,
-      nativeStreamer: buildNativeStreamerSessionContext(activeSession, streamSettings),
-    };
-  }, [buildCurrentStreamSettings]);
-
   const warmNativeStreamerForLaunch = useCallback((): void => {
     if (settings.streamClientMode !== "native") {
       return;
@@ -1198,6 +1190,27 @@ export function App(): JSX.Element {
     settings.shortcutScreenshot,
     settings.shortcutToggleRecording,
   ]);
+
+  const nativeStreamerShortcuts = useMemo(() => ({
+    toggleStats: shortcuts.toggleStats.canonical,
+    togglePointerLock: shortcuts.togglePointerLock.canonical,
+    toggleFullscreen: shortcuts.toggleFullscreen.canonical,
+    stopStream: shortcuts.stopStream.canonical,
+    toggleAntiAfk: shortcuts.toggleAntiAfk.canonical,
+    toggleMicrophone: shortcuts.toggleMicrophone.canonical,
+    screenshot: shortcuts.screenshot.canonical,
+    toggleRecording: shortcuts.recording.canonical,
+  }), [shortcuts]);
+
+  const buildSignalingConnectRequest = useCallback((activeSession: SessionInfo): SignalingConnectRequest => {
+    const streamSettings = buildCurrentStreamSettings();
+    return {
+      sessionId: activeSession.sessionId,
+      signalingServer: activeSession.signalingServer,
+      signalingUrl: activeSession.signalingUrl,
+      nativeStreamer: buildNativeStreamerSessionContext(activeSession, streamSettings, nativeStreamerShortcuts),
+    };
+  }, [buildCurrentStreamSettings, nativeStreamerShortcuts]);
 
   const setSessionFullscreen = useCallback(async (nextFullscreen: boolean) => {
     const canUseNativeFullscreen = typeof window.openNow?.setFullscreen === "function";
@@ -2437,6 +2450,8 @@ export function App(): JSX.Element {
           if (nativeStreamingRef.current || sessionRef.current) {
             activateNativeInputForCurrentSession(event.protocolVersion);
           }
+        } else if (event.type === "native-shortcut") {
+          handleStreamShortcutAction(event.action);
         } else if (event.type === "native-stream-stats") {
           diagnosticsStore.set(mergeNativeStreamStats(
             diagnosticsStore.getSnapshot(),
@@ -3365,6 +3380,55 @@ export function App(): JSX.Element {
     await handleStopStream();
   }, [handleStopStream, releasePointerLockIfNeeded, requestExitPrompt, streamStatus, streamingGame?.title, t]);
 
+  const handleStreamShortcutAction = useCallback((action: NativeStreamerShortcutAction): void => {
+    switch (action) {
+      case "toggleStats":
+        setShowStatsOverlay((prev) => !prev);
+        return;
+      case "togglePointerLock":
+        {
+          const targetVideo = videoRef.current;
+          if (streamStatus === "streaming" && targetVideo) {
+            if (document.pointerLockElement === targetVideo) {
+              const client = clientRef.current as { suppressNextSyntheticEscape?: boolean } | null;
+              if (client) {
+                client.suppressNextSyntheticEscape = true;
+              }
+              document.exitPointerLock();
+            } else {
+              void requestPointerLockCapture(targetVideo);
+            }
+          }
+        }
+        return;
+      case "toggleFullscreen":
+        if (streamStatus === "connecting" || streamStatus === "streaming") {
+          void toggleSessionFullscreen();
+        }
+        return;
+      case "stopStream":
+        void handlePromptedStopStream();
+        return;
+      case "toggleAntiAfk":
+        if (streamStatus === "streaming") {
+          setAntiAfkEnabled((prev) => !prev);
+          setAntiAfkAckNonce((n) => n + 1);
+        }
+        return;
+      case "toggleMicrophone":
+        if (streamStatus === "streaming") {
+          clientRef.current?.toggleMicrophone();
+        }
+        return;
+      case "screenshot":
+      case "toggleRecording":
+        if (streamStatus === "streaming") {
+          dispatchStreamShortcutAction(action);
+        }
+        return;
+    }
+  }, [handlePromptedStopStream, requestPointerLockCapture, streamStatus, toggleSessionFullscreen]);
+
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -3425,7 +3489,7 @@ export function App(): JSX.Element {
         e.preventDefault();
         e.stopPropagation();
         e.stopImmediatePropagation();
-        setShowStatsOverlay((prev) => !prev);
+        handleStreamShortcutAction("toggleStats");
         return;
       }
 
@@ -3433,6 +3497,8 @@ export function App(): JSX.Element {
         e.preventDefault();
         e.stopPropagation();
         e.stopImmediatePropagation();
+        handleStreamShortcutAction("togglePointerLock");
+        return;
         if (streamStatus === "streaming" && videoRef.current) {
           if (document.pointerLockElement === videoRef.current) {
             try {
@@ -3442,7 +3508,7 @@ export function App(): JSX.Element {
             }
             document.exitPointerLock();
           } else {
-            void requestPointerLockCapture(videoRef.current);
+            void requestPointerLockCapture(videoRef.current!);
           }
         }
         return;

--- a/opennow-stable/src/renderer/src/App.tsx
+++ b/opennow-stable/src/renderer/src/App.tsx
@@ -327,6 +327,7 @@ export function App(): JSX.Element {
   const codecStartupTestAttemptedRef = useRef(false);
   const navbarSessionActionInFlightRef = useRef<"resume" | "terminate" | null>(null);
   const nativeStreamingRef = useRef(false);
+  const handleStreamShortcutActionRef = useRef<((action: NativeStreamerShortcutAction) => void) | null>(null);
 
   const resetStatsOverlayToPreference = useCallback((): void => {
     setShowStatsOverlay(settings.showStatsOnLaunch);
@@ -2451,7 +2452,7 @@ export function App(): JSX.Element {
             activateNativeInputForCurrentSession(event.protocolVersion);
           }
         } else if (event.type === "native-shortcut") {
-          handleStreamShortcutAction(event.action);
+          handleStreamShortcutActionRef.current?.(event.action);
         } else if (event.type === "native-stream-stats") {
           diagnosticsStore.set(mergeNativeStreamStats(
             diagnosticsStore.getSnapshot(),
@@ -3428,6 +3429,10 @@ export function App(): JSX.Element {
         return;
     }
   }, [handlePromptedStopStream, requestPointerLockCapture, streamStatus, toggleSessionFullscreen]);
+
+  useEffect(() => {
+    handleStreamShortcutActionRef.current = handleStreamShortcutAction;
+  }, [handleStreamShortcutAction]);
 
   // Keyboard shortcuts
   useEffect(() => {

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -1481,6 +1481,40 @@ export function StreamView({
   }, [captureScreenshot, toggleRecording]);
 
   useEffect(() => {
+    const screenshotShortcut = normalizeShortcut(shortcuts.screenshot);
+    const recordingShortcut = normalizeShortcut(shortcuts.recording);
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const isTyping = !!target && (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      );
+      if (isTyping) {
+        return;
+      }
+
+      if (isShortcutMatch(event, screenshotShortcut)) {
+        event.preventDefault();
+        event.stopPropagation();
+        void captureScreenshot();
+        return;
+      }
+
+      if (isShortcutMatch(event, recordingShortcut)) {
+        event.preventDefault();
+        event.stopPropagation();
+        void toggleRecording();
+        return;
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [captureScreenshot, shortcuts.screenshot, shortcuts.recording, toggleRecording]);
+
+  useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       const target = event.target as HTMLElement | null;
       const isTyping = !!target && (

--- a/opennow-stable/src/renderer/src/components/StreamView.tsx
+++ b/opennow-stable/src/renderer/src/components/StreamView.tsx
@@ -11,6 +11,7 @@ import { getStoreDisplayName, getStoreIconComponent } from "./GameCard";
 import { RemainingPlaytimeIndicator, SessionElapsedIndicator } from "./ElapsedSessionIndicators";
 import type { MicrophoneMode, ScreenshotEntry, RecordingEntry, SubscriptionInfo } from "@shared/gfn";
 import { formatShortcutForDisplay, isShortcutMatch, normalizeShortcut, shortcutFromKeyboardEvent } from "../shortcuts";
+import { addStreamShortcutActionListener } from "../streamShortcutActions";
 import { useMicMeter } from "../hooks/useMicMeter";
 import {
   getBitratePerformanceColor,
@@ -1468,8 +1469,18 @@ export function StreamView({
   }, [onReleasePointerLock]);
 
   useEffect(() => {
-    const screenshotShortcut = normalizeShortcut(shortcuts.screenshot);
-    const recordingShortcut = normalizeShortcut(shortcuts.recording);
+    return addStreamShortcutActionListener((action) => {
+      if (action === "screenshot") {
+        void captureScreenshot();
+        return;
+      }
+      if (action === "toggleRecording") {
+        void toggleRecording();
+      }
+    });
+  }, [captureScreenshot, toggleRecording]);
+
+  useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       const target = event.target as HTMLElement | null;
       const isTyping = !!target && (
@@ -1478,20 +1489,6 @@ export function StreamView({
         target.isContentEditable
       );
       if (isTyping) {
-        return;
-      }
-
-      if (isShortcutMatch(event, screenshotShortcut)) {
-        event.preventDefault();
-        event.stopPropagation();
-        void captureScreenshot();
-        return;
-      }
-
-      if (isShortcutMatch(event, recordingShortcut)) {
-        event.preventDefault();
-        event.stopPropagation();
-        void toggleRecording();
         return;
       }
 
@@ -1509,7 +1506,7 @@ export function StreamView({
 
     window.addEventListener("keydown", onKeyDown, true);
     return () => window.removeEventListener("keydown", onKeyDown, true);
-  }, [captureScreenshot, handleToggleSideBar, isMacClient, shortcuts.screenshot, shortcuts.recording, toggleRecording]);
+  }, [handleToggleSideBar, isMacClient]);
 
   return (
     <div className={["sv", className].filter(Boolean).join(" ")}>

--- a/opennow-stable/src/renderer/src/streamShortcutActions.ts
+++ b/opennow-stable/src/renderer/src/streamShortcutActions.ts
@@ -1,0 +1,22 @@
+import type { NativeStreamerShortcutAction } from "@shared/gfn";
+
+const STREAM_SHORTCUT_ACTION_EVENT = "opennow:stream-shortcut-action";
+
+export function dispatchStreamShortcutAction(action: NativeStreamerShortcutAction): void {
+  window.dispatchEvent(new CustomEvent<NativeStreamerShortcutAction>(STREAM_SHORTCUT_ACTION_EVENT, {
+    detail: action,
+  }));
+}
+
+export function addStreamShortcutActionListener(
+  listener: (action: NativeStreamerShortcutAction) => void,
+): () => void {
+  const handler: EventListener = (event) => {
+    listener((event as CustomEvent<NativeStreamerShortcutAction>).detail);
+  };
+
+  window.addEventListener(STREAM_SHORTCUT_ACTION_EVENT, handler);
+  return () => {
+    window.removeEventListener(STREAM_SHORTCUT_ACTION_EVENT, handler);
+  };
+}

--- a/opennow-stable/src/shared/gfn.test.ts
+++ b/opennow-stable/src/shared/gfn.test.ts
@@ -139,6 +139,16 @@ test("buildNativeStreamerSessionContext forwards requested/finalized streaming f
         forceQueueMode: "adaptive",
       },
     },
+    {
+      toggleStats: "F3",
+      togglePointerLock: "F8",
+      toggleFullscreen: "F10",
+      stopStream: "Ctrl+Shift+Q",
+      toggleAntiAfk: "Ctrl+Shift+K",
+      toggleMicrophone: "Ctrl+Shift+M",
+      screenshot: "F11",
+      toggleRecording: "F12",
+    },
   );
 
   assert.deepEqual(context.session.requestedStreamingFeatures, {
@@ -158,6 +168,7 @@ test("buildNativeStreamerSessionContext forwards requested/finalized streaming f
   assert.equal(context.session.negotiatedStreamProfile?.codec, "H265");
   assert.equal(context.settings.enableCloudGsync, false);
   assert.equal(context.settings.nativeTransitionDiagnostics?.forceQueueMode, "adaptive");
+  assert.equal(context.shortcuts.toggleRecording, "F12");
 });
 
 test("normalizes native stream client mode to web on non-Windows platforms", () => {

--- a/opennow-stable/src/shared/gfn.ts
+++ b/opennow-stable/src/shared/gfn.ts
@@ -865,14 +865,37 @@ export interface SendAnswerRequest {
   nvstSdp?: string;
 }
 
+export type NativeStreamerShortcutAction =
+  | "toggleStats"
+  | "togglePointerLock"
+  | "toggleFullscreen"
+  | "stopStream"
+  | "toggleAntiAfk"
+  | "toggleMicrophone"
+  | "screenshot"
+  | "toggleRecording";
+
+export interface NativeStreamerShortcutBindings {
+  toggleStats: string;
+  togglePointerLock: string;
+  toggleFullscreen: string;
+  stopStream: string;
+  toggleAntiAfk: string;
+  toggleMicrophone: string;
+  screenshot: string;
+  toggleRecording: string;
+}
+
 export interface NativeStreamerSessionContext {
   session: SessionInfo;
   settings: StreamSettings;
+  shortcuts: NativeStreamerShortcutBindings;
 }
 
 export function buildNativeStreamerSessionContext(
   session: SessionInfo,
   settings: StreamSettings,
+  shortcuts: NativeStreamerShortcutBindings,
 ): NativeStreamerSessionContext {
   const negotiatedStreamProfile = session.negotiatedStreamProfile
     ? {
@@ -891,6 +914,7 @@ export function buildNativeStreamerSessionContext(
       enableCloudGsync:
         session.negotiatedStreamProfile?.enableCloudGsync ?? settings.enableCloudGsync,
     },
+    shortcuts,
   };
 }
 
@@ -946,6 +970,7 @@ export type MainToRendererSignalingEvent =
   | { type: "disconnected"; reason: string }
   | { type: "offer"; sdp: string }
   | { type: "remote-ice"; candidate: IceCandidatePayload }
+  | { type: "native-shortcut"; action: NativeStreamerShortcutAction }
   | { type: "native-stream-started"; message?: string }
   | { type: "native-stream-stopped"; reason?: string }
   | { type: "native-stream-stats"; stats: NativeStreamStats }

--- a/opennow-stable/src/shared/nativeStreamer.ts
+++ b/opennow-stable/src/shared/nativeStreamer.ts
@@ -3,6 +3,7 @@ import type {
   NativeStreamerBackend,
   NativeStreamStats,
   NativeRenderSurface,
+  NativeStreamerShortcutAction,
   NativeStreamerSessionContext,
   NativeVideoTransition,
   NativeVideoBackendCapability,
@@ -113,6 +114,10 @@ export type NativeStreamerEvent =
   | {
       type: "input-ready";
       protocolVersion: number;
+    }
+  | {
+      type: "shortcut";
+      action: NativeStreamerShortcutAction;
     }
   | {
       type: "video-stall";


### PR DESCRIPTION
## Description

- pass the existing configurable stream shortcut bindings into the native streamer session context
- add a native shortcut matcher around the Win32/GStreamer input bridge so app shortcuts are intercepted before being forwarded into the stream
- route native shortcut actions back through the existing renderer control flow, while keeping native pointer-lock capture toggling local to the streamer window

## Verification

- `npm --prefix opennow-stable run typecheck`
- `npm --prefix opennow-stable run build`
- `cargo test` (in `native/opennow-streamer`)
